### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -376,7 +376,7 @@ An example for asynchronous search and modify with `asyncio`:
     @asyncio.coroutine
     def do():
         cli = bonsai.LDAPClient("ldap://localhost")
-        with (yield from cli.connect(async=True)) as conn:
+        with (yield from cli.connect(is_async=True)) as conn:
             results = yield from conn.search("ou=nerdherd,dc=bonsai,dc=test", 1)
             for res in results:
                 print(res['givenName'][0])


### PR DESCRIPTION
Fix a small typo in the documentation: the correct parameter name seems to be "is_async" not "async".