### PR TITLE
RFC: Passing NULL credentials to bind.

### DIFF
--- a/src/_bonsai/ldap-xplat.c
+++ b/src/_bonsai/ldap-xplat.c
@@ -612,12 +612,22 @@ create_conn_info(char *mech, SOCKET sock, PyObject *creds) {
         if (strcmp(mech, "SIMPLE") == 0) {
             binddn = PyObject2char(PyDict_GetItemString(creds, "user"));
         } else {
+# ifdef WIN32
+            PyObject2char_advanced(PyDict_GetItemString(creds, "user"), &authcid, NULL, 1);
+            PyObject2char_advanced(PyDict_GetItemString(creds, "realm"), &realm, NULL, 1);
+            PyObject2char_advanced(PyDict_GetItemString(creds, "authz_id"), &authzid, NULL, 1);
+# else
             authcid = PyObject2char(PyDict_GetItemString(creds, "user"));
             realm = PyObject2char(PyDict_GetItemString(creds, "realm"));
             authzid = PyObject2char(PyDict_GetItemString(creds, "authz_id"));
+# endif
             ktname = PyObject2char(PyDict_GetItemString(creds, "keytab"));
         }
+# ifdef WIN32
+        PyObject2char_advanced(PyDict_GetItemString(creds, "password"), &passwd, NULL, 1);
+# else
         passwd = PyObject2char(PyDict_GetItemString(creds, "password"));
+# endif
     }
 
     defaults = malloc(sizeof(ldap_conndata_t));

--- a/src/_bonsai/utils.h
+++ b/src/_bonsai/utils.h
@@ -33,6 +33,7 @@ extern char asyncmod;
 char *lowercase(char *str);
 struct berval *create_berval(char *value, long int len);
 PyObject *berval2PyObject(struct berval *bval, int keepbytes);
+int PyObject2char_advanced(PyObject *obj, char **output, long int *len, int noneisnull);
 int PyObject2char_withlength(PyObject *obj, char **output, long int *len);
 char *PyObject2char(PyObject *obj);
 struct berval **PyList2BervalList(PyObject *list);


### PR DESCRIPTION
The WinLDAP API supports binding using the current user using the GSS-SPNEGO mechanism without supplying any password or username. It is quite underdocumented but it is hinted at in the [ldap_bind_s documentation](https://docs.microsoft.com/da-dk/windows/win32/api/winldap/nf-winldap-ldap_bind_s) under the remarks for LDAP_AUTH_NEGOTIATE. I have no experience with libldap2 or WinLDAP so I do not know if passing NULL credentials to other authentication mechanisms or on other platforms is valid.

In this pull request I have implemented a variant of PyObject2char named PyObject2char_advanced which allows to convert None to NULL strings rather than empty strings. And then I have applied this version to user, realm, auth_zid and password for WIN32 platforms. And with GSS-SPNEGO this has the desired effect on Windows.

I don't think the implementation in this pull request is ready for merge, but I hope that we can discuss how to implement this feature properly.