### PR TITLE
tests: fix attribute error with tornado 6.2.0

### DIFF
--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -42,6 +42,7 @@ class TornadoLDAPConnectionTest(TestCaseClass):
 
     def setUp(self):
         """ Set LDAP URL and open connection. """
+        super().setUp()
         self.cfg = get_config()
         self.url = "ldap://%s:%s/%s?%s?%s" % (
             self.cfg["SERVER"]["hostip"],


### PR DESCRIPTION
Fix the following error when running tests with tornado 6.2.0:

```
>       if self.should_close_asyncio_loop:
E       AttributeError: 'TornadoLDAPConnectionTest' object has no
        attribute 'should_close_asyncio_loop'
/usr/lib/python3/dist-packages/tornado/testing.py:282: AttributeError
```

Since 6.2.0, tornado.AsyncTestCase.setUp() performs attributes
initialization. It needs to be called by subclasses.

I did not bump the tornado version in `pyproject.toml`. Should I do so?