### PR TITLE
Avoid UnboundLocalError in AIOConnectionPool.spawn

### DIFF
--- a/src/bonsai/asyncio/aiopool.py
+++ b/src/bonsai/asyncio/aiopool.py
@@ -84,10 +84,12 @@ class AIOConnectionPool(ConnectionPool):
 
     @asynccontextmanager
     async def spawn(self, *args, **kwargs):
+        conn = None
         try:
             if self._closed:
                 await self.open()
             conn = await self.get(*args, **kwargs)
             yield conn
         finally:
-            await self.put(conn)
+            if conn:
+                await self.put(conn)


### PR DESCRIPTION
get() may fail with an exception and thus not return if the remote
LDAP server is inaccessible and the pool has no idle connections,
but spawn() unconditionally attempts to return the connection
returned by get() to the pool in a finally block.  This can result
in an UnboundLocalError for conn, since the local variable is only
created on successful return from get().

Handle this by initializing conn and not attempting to return it to
the pool if it's still None.