### PR TITLE
Run ldconfig in Dockerfile-client after make install

### DIFF
--- a/.ci/docker/Dockerfile-client
+++ b/.ci/docker/Dockerfile-client
@@ -8,10 +8,10 @@ RUN curl -sL https://www.openldap.org/software/download/OpenLDAP/openldap-releas
 
 WORKDIR /openldap-${OPENLDAP_VERSION}
 RUN ./configure --with-tls=openssl --disable-slapd --enable-backends=no
-RUN make depend && make && make install
+RUN make depend && make && make install && ldconfig
 
 WORKDIR /
-RUN apt-get remove -y libldap-2.4-2
+RUN apt-get remove -y 'libldap-*' && ldconfig
 RUN python -m pip install -U pip poetry
 
 CMD tail -f /dev/null


### PR DESCRIPTION
## What

Run `ldconfig` explicitly after `make install` and after `apt-get remove`, and match `libldap-*` instead of the now-nonexistent `libldap-2.4-2`.

## Why

After commit 0bf39a6 switched the docker base from `python:*-slim-bullseye` to `python:*-slim-bookworm`, the client image's `apt-get remove -y libldap-2.4-2` became a no-op because bookworm ships `libldap-2.5-0` under a different package name. The hidden side effect that line previously had — triggering dpkg's post-remove `ldconfig` — also stopped happening, leaving the freshly-built `/usr/local/lib/libldap.so.2` out of the runtime linker cache.

The result: every test in the `Docker newestOpenLDAP` and `Docker nightlyPython` jobs fails at import time with `ImportError: libldap.so.2: cannot open shared object file`.

This was first surfaced by the Azure run on PR #108 (the first build to run since the bookworm switch). Reproduces locally with the same docker steps Azure uses.

## Verification

Built the image locally with this fix and ran the equivalent of Azure's `Run tests` step against the test container: 229 passed, 23 skipped, 1 failure (`test_ldapi`, an unrelated Unix-domain-socket bind-mount limitation that affects local repros, not Azure).

The SONAME-based linker resolution means the apt-installed system libldap (different SONAME, `libldap-2.5.so.0`) cannot accidentally shadow the freshly-built one — but the maintainer's intent of removing it for clarity is preserved by the wildcard pattern.
