### PR TITLE
Release the GIL during connect; open AIOLDAPConnection off the event loop (fixes #107)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,17 @@
 Changelog
 ==========
+[Unreleased]
+------------
+
+Fixed
+~~~~~
+
+-  AIOLDAPConnection no longer blocks the asyncio event loop while connecting
+   to an unreachable or slow host, and it honours the connect timeout. The
+   blocking DNS resolution and TCP connect now run in a thread executor with
+   the GIL released, and the connect is bounded by a network timeout.
+
+
 [1.5.5 - 2026-02-18]
 --------------------
 

--- a/src/_bonsai/ldap-xplat.c
+++ b/src/_bonsai/ldap-xplat.c
@@ -504,8 +504,11 @@ _ldap_bind(LDAP *ld, ldap_conndata_t *info, char ppolicy, LDAPMessage *result, i
     /* Mechanism is set, use SASL interactive bind. */
     if (strcmp(info->mech, "SIMPLE") != 0) {
         if (info->passwd == NULL) info->passwd = "";
+        /* Release the GIL: this call performs the blocking DNS + TCP connect. */
+        Py_BEGIN_ALLOW_THREADS
         rc = ldap_sasl_interactive_bind(ld, info->binddn, info->mech, server_ctrls, NULL,
                 LDAP_SASL_QUIET, sasl_interact, info, result, &(info->rmech), msgid);
+        Py_END_ALLOW_THREADS
     } else {
         if (info->passwd == NULL) {
             passwd.bv_len = 0;
@@ -513,8 +516,11 @@ _ldap_bind(LDAP *ld, ldap_conndata_t *info, char ppolicy, LDAPMessage *result, i
             passwd.bv_len = strlen(info->passwd);
         }
         passwd.bv_val = info->passwd;
+        /* Release the GIL: this call performs the blocking DNS + TCP connect. */
+        Py_BEGIN_ALLOW_THREADS
         rc = ldap_sasl_bind(ld, info->binddn, LDAP_SASL_SIMPLE, &passwd, server_ctrls,
                 NULL, msgid);
+        Py_END_ALLOW_THREADS
     }
 
     if (ppolicy_ctrl != NULL) ldap_control_free(ppolicy_ctrl);

--- a/src/_bonsai/ldapconnection.c
+++ b/src/_bonsai/ldapconnection.c
@@ -55,6 +55,7 @@ ldapconnection_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
         self->async = 0;
         self->ppolicy = 0;
         self->csock = -1;
+        self->connect_timeout = -1;
         self->socketpair = NULL;
     }
 
@@ -186,9 +187,13 @@ connecting(LDAPConnection *self, LDAPConnectIter **conniter) {
 
 /* Open the LDAP connection. */
 static PyObject *
-ldapconnection_open(LDAPConnection *self) {
+ldapconnection_open(LDAPConnection *self, PyObject *args) {
     int rc = 0;
+    int connect_timeout = -1;
     LDAPConnectIter *iter = NULL;
+
+    if (!PyArg_ParseTuple(args, "|i", &connect_timeout)) return NULL;
+    self->connect_timeout = connect_timeout;
 
     DEBUG("ldapconnection_open (self:%p)", self);
     rc = connecting(self, &iter);
@@ -1410,7 +1415,7 @@ static PyMethodDef ldapconnection_methods[] = {
             "Get the socket descriptor that belongs to the connection."},
     {"get_result", (PyCFunction)ldapconnection_result, METH_VARARGS | METH_KEYWORDS,
             "Poll the status of the operation associated with the given message id from LDAP server."},
-    {"open", (PyCFunction)ldapconnection_open, METH_NOARGS,
+    {"open", (PyCFunction)ldapconnection_open, METH_VARARGS,
             "Open connection with the LDAP Server."},
     {"modify_password", (PyCFunction)ldapconnection_modpasswd, METH_VARARGS | METH_KEYWORDS,
             "Modify password for the user."},

--- a/src/_bonsai/ldapconnection.h
+++ b/src/_bonsai/ldapconnection.h
@@ -19,6 +19,7 @@ typedef struct {
     char managedsait;
     char ignore_referrals;
     SOCKET csock;
+    int connect_timeout;
     PyObject *socketpair;
 } LDAPConnection;
 

--- a/src/_bonsai/ldapconnectiter.c
+++ b/src/_bonsai/ldapconnectiter.c
@@ -578,8 +578,23 @@ LDAPConnectIter_Next(LDAPConnectIter *self, int timeout) {
 
     /* Start building TLS Connection, if needed. */
     if (self->state == 1) {
+#ifndef WIN32
+        /* On the default (non-async-connect) path, bound the synchronous connect
+           so a timed-out connect worker releases near the deadline instead of
+           waiting out the OS-level TCP timeout. */
+        if (_g_asyncmod == 0 && self->conn->connect_timeout > 0) {
+            struct timeval tv;
+            tv.tv_sec = self->conn->connect_timeout / 1000;
+            tv.tv_usec = (self->conn->connect_timeout % 1000) * 1000;
+            ldap_set_option(self->conn->ld, LDAP_OPT_NETWORK_TIMEOUT, &tv);
+        }
+#endif
         if (self->tls == 1) {
+            /* Release the GIL: for the TLS-first path this triggers the
+               blocking DNS + TCP connect when sending the StartTLS request. */
+            Py_BEGIN_ALLOW_THREADS
             rc = ldap_start_tls(self->conn->ld, NULL, NULL, &(self->tls_id));
+            Py_END_ALLOW_THREADS
             if (rc == LDAP_SUCCESS) {
                 self->state = 2;
             } else {

--- a/src/bonsai/asyncio/aioconnection.py
+++ b/src/bonsai/asyncio/aioconnection.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from .._bonsai import ldapconnection
 from ..ldapconnection import BaseLDAPConnection, LDAPSearchScope
 from ..errors import LDAPError, NotAllowedOnNonleaf
 
@@ -18,6 +19,7 @@ class AIOLDAPConnection(BaseLDAPConnection):
     def __init__(self, client, loop=None):
         self._loop = loop or asyncio.get_running_loop()
         self.__open_coro = None
+        self.__connect_future = None
         super().__init__(client, is_async=True)
 
     async def __aenter__(self):
@@ -62,8 +64,80 @@ class AIOLDAPConnection(BaseLDAPConnection):
         return self._poll(msg_id, timeout)
 
     def open(self, timeout=None):
-        self.__open_coro = super().open(timeout)
+        # Start the init thread (no network I/O) and get the message id, then
+        # drive the connect in a coroutine that keeps the event loop responsive.
+        if timeout is None:
+            msg_id = ldapconnection.open(self)
+        else:
+            # Bound the connect worker thread with LDAP_OPT_NETWORK_TIMEOUT. The
+            # 1s margin keeps it above the asyncio wait_for deadline so the
+            # caller reliably sees asyncio.TimeoutError, not a connection error.
+            msg_id = ldapconnection.open(self, int(timeout * 1000) + 1000)
+        self.__open_coro = self._open(msg_id, timeout)
         return self
+
+    @staticmethod
+    def _set_future_result(fut):
+        if not fut.done():
+            fut.set_result(None)
+
+    @staticmethod
+    def _retrieve_connect_result(fut):
+        # Retrieve the (possibly discarded) result/exception of the connect
+        # worker so asyncio does not log it as never-retrieved.
+        if not fut.cancelled():
+            fut.exception()
+
+    def _connect_step(self, msg_id):
+        # Runs in a worker thread. The C extension releases the GIL during the
+        # blocking DNS resolution and TCP connect, so the event loop stays free.
+        # Do NOT pass a timeout to get_result: it sets self->timeout on the C
+        # LDAPConnectIter, which would make the Phase 2 _ready callbacks block
+        # the event loop waiting for the bind response. The timeout is enforced
+        # by the asyncio wait_for wrapping this call.
+        return super().get_result(msg_id)
+
+    async def _open(self, msg_id, timeout=None):
+        loop = self._loop
+        deadline = None if timeout is None else loop.time() + timeout
+        # Phase 1a: wait for the init thread to finish initialising the LDAP
+        # struct. It pings the dummy socketpair when done; this does no network.
+        init_done = loop.create_future()
+        init_fd = self.fileno()
+        loop.add_reader(init_fd, self._set_future_result, init_done)
+        try:
+            await asyncio.wait_for(init_done, timeout)
+        finally:
+            loop.remove_reader(init_fd)
+        # Phase 1b: run the blocking connect (DNS + TCP connect + bind start) in
+        # a worker thread, bounded by the remaining timeout. On timeout the
+        # worker cannot be cancelled; it keeps running (until its own network
+        # timeout). Shield it so wait_for's timeout does not mark the future
+        # done while the worker is still using the LDAP handle -- close() relies
+        # on this future to know when the handle is safe to unbind.
+        remaining = None if deadline is None else max(0.0, deadline - loop.time())
+        connect_future = loop.run_in_executor(None, self._connect_step, msg_id)
+        self.__connect_future = connect_future
+        connect_future.add_done_callback(self._retrieve_connect_result)
+        res = await asyncio.wait_for(asyncio.shield(connect_future), remaining)
+        if res is not None:
+            return res
+        # Phase 2: the socket is connected and the bind request is sent; drive
+        # the rest of the bind exchange with the existing non-blocking polling.
+        remaining = None if deadline is None else max(0.0, deadline - loop.time())
+        return await self._poll(msg_id, remaining)
+
+    def close(self, *args, **kwargs):
+        connect_future = self.__connect_future
+        if connect_future is not None and not connect_future.done():
+            # A connect worker thread may still be using the LDAP handle; defer
+            # the unbind until it finishes to avoid a use-after-free.
+            self.__connect_future = None
+            connect_future.add_done_callback(
+                lambda _: ldapconnection.close(self, *args, **kwargs)
+            )
+            return
+        super().close(*args, **kwargs)
 
     async def delete(self, dname, timeout=None, recursive=False):
         try:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -284,3 +284,67 @@ async def test_pool_spawn(client):
         _ = await conn.whoami()
     assert pool.idle_connection == 1
     assert pool.shared_connection == 0
+
+
+@pytest.mark.timeout(30)
+@asyncio_test
+async def test_open_keeps_event_loop_responsive(client):
+    """Opening to a slow/unreachable host must not freeze the loop, and the
+    connect timeout must be honored (not the full network round-trip time)."""
+    max_gap = 0.0
+
+    async def heartbeat():
+        nonlocal max_gap
+        last = time.monotonic()
+        while True:
+            await asyncio.sleep(0.05)
+            now = time.monotonic()
+            max_gap = max(max_gap, now - last)
+            last = now
+
+    hb = asyncio.ensure_future(heartbeat())
+    try:
+        with network_delay(4.0):
+            start = time.time()
+            with pytest.raises(asyncio.TimeoutError):
+                await client.connect(True, timeout=2.0)
+            elapsed = time.time() - start
+        # The loop never stalled for long while the connect was in flight
+        # (a frozen connect would leave a multi-second gap between heartbeats).
+        assert max_gap < 1.0
+        # The timeout fired near 2s, not at the ~4s network delay.
+        assert elapsed < 3.5
+    finally:
+        hb.cancel()
+        try:
+            await hb
+        except asyncio.CancelledError:
+            pass
+
+
+@asyncio_test
+async def test_starttls_connection(cfg):
+    """A StartTLS connection opens through the two-phase async open."""
+    url = "ldap://%s:%s" % (cfg["SERVER"]["hostname"], cfg["SERVER"]["port"])
+    tls_client = bonsai.LDAPClient(url, tls=True)
+    tls_client.set_cert_policy("allow")
+    tls_client.set_credentials(
+        "SIMPLE", cfg["SIMPLEAUTH"]["user"], cfg["SIMPLEAUTH"]["password"]
+    )
+    async with tls_client.connect(True, timeout=10) as conn:
+        assert conn.closed is False
+        assert (await conn.whoami()) is not None
+
+
+@pytest.mark.timeout(30)
+@asyncio_test
+async def test_close_after_connect_timeout(client):
+    """Closing right after a connect timeout must be safe while the connect
+    worker thread may still be using the LDAP handle (no use-after-free)."""
+    conn = client.connect(True, timeout=2.0)
+    with network_delay(4.0):
+        with pytest.raises(asyncio.TimeoutError):
+            await conn
+        conn.close()  # unbind must be deferred, not run under the live worker
+    # Let the still-running connect worker finish so the deferred unbind runs.
+    await asyncio.sleep(4.0)


### PR DESCRIPTION
## Summary

`LDAPClient.connect()` performs the blocking DNS resolution and TCP connect inside the first `ldap_sasl_bind` / `ldap_start_tls`, and bonsai ran that **with the GIL held**. As reported in #107, while one thread opens a connection every other Python thread is blocked; for `AIOLDAPConnection` this freezes the entire asyncio event loop, and a slow/unreachable host hangs for the OS-level TCP timeout while the `timeout` argument is ignored.

## Changes

- **Release the GIL** around `ldap_sasl_bind`, `ldap_sasl_interactive_bind` (`_ldap_bind`) and `ldap_start_tls` — the calls that run the blocking connect/handshake. They touch no Python objects, and the `sasl_interact` callback only reads the C `ldap_conndata_t`, so this is safe. This alone lets other threads (and the event loop) run during a connect (#107).
- **Two-phase async open** in `AIOLDAPConnection`: wait for the (network-free) init thread, run the connecting `get_result` in `loop.run_in_executor()` bounded by `asyncio.wait_for(timeout)`, then hand off to the existing fd-polling for the bind exchange. The loop stays responsive and the connect `timeout` is honoured.
- **Bound the connect worker** with `LDAP_OPT_NETWORK_TIMEOUT` (set from the connect timeout, async path only, leaving the poll timeval untouched) so a timed-out connect's uncancellable worker thread releases near the deadline instead of waiting out the kernel TCP timeout.
- **Safe `close()`**: the unbind is deferred until the connect worker finishes, avoiding a use-after-free if the caller closes during the timeout window.

This deliberately does **not** enable `set_connect_async` or change the StartTLS ordering, so it avoids the regression that disabled async-connect by default. (It also gives a non-blocking connect without `set_connect_async`, which side-steps #110, though that issue's `connect_async` hang is not addressed here.)

## Test plan

New `tests/test_asyncio.py` cases, run against the docker test server (OpenLDAP 2.6):

- [x] `test_open_keeps_event_loop_responsive` — the max gap between heartbeats stays < 1s while connecting to a delayed host, and `TimeoutError` fires near the requested timeout (not the full round-trip).
- [x] `test_starttls_connection` — StartTLS open works through the two-phase open.
- [x] `test_close_after_connect_timeout` — closing right after a connect timeout is safe.
- [x] Full asyncio suite: 19/19 pass.
- [x] Sync / other-framework suites: same pass/fail set as `master` (no regressions).
- [x] Manual (iptables-blackholed host): loop stays responsive, `TimeoutError` at the deadline, process exits at ~timeout+1s instead of ~127s.

Fixes #107.