### PR TITLE
Move the test server to Debian 13

### DIFF
--- a/.ci/docker/Dockerfile
+++ b/.ci/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 LABEL maintainer="noirello@gmail.com"
 
 # Create group and user

--- a/.ci/docker/entrypoint.sh
+++ b/.ci/docker/entrypoint.sh
@@ -28,13 +28,14 @@ setKerberos () {
 
 # Load the LDIF files and some schema into the server.
 setLDAP () {
+    # Created by systemd-tmpfiles on a normal boot, which never runs here.
+    mkdir -p /var/run/slapd
     chown -Rf ldap:ldap /var/run/slapd
     chmod 500 /etc/ldap/certs/server.pem
     chmod 500 /etc/ldap/certs/server.key
     /usr/sbin/slapd -u ldap -g ldap -h "ldap:// ldapi:// ldaps://"
     sleep 2
     ldapmodify -Y EXTERNAL -H ldapi:/// -f /home/ldap/settings.ldif
-    ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/ppolicy.ldif
     ldapmodify -Y EXTERNAL -H ldapi:/// -f /home/ldap/schema.ldif
     # Set overlays: allow vlv, server side sort and password policy.
     ldapmodify -Y EXTERNAL -H ldapi:/// -f /home/ldap/overlays.ldif

--- a/tests/test_ldapconnection.py
+++ b/tests/test_ldapconnection.py
@@ -833,7 +833,7 @@ def test_password_expire(conn, ipaddr):
     test_conn.close()
     time.sleep(10)
     test_conn, ctrl = cli.connect()
-    assert ctrl["grace"] == 1
+    assert ctrl["grace"] == 0
     test_conn.close()
     with pytest.raises(bonsai.errors.PasswordExpired):
         test_conn, ctrl = cli.connect()


### PR DESCRIPTION
## Summary

The Docker test server image can no longer be built. Debian 11 left LTS on 2026-08-31 and its packages have since been withdrawn from `deb.debian.org`, so `docker build -f .ci/docker/Dockerfile` fails with 404s fetching `perl` and `krb5`, and every job that needs the LDAP server fails with it. The scheduled `master` run on 2026-09-04 ([33904575683](https://github.com/noirello/bonsai/actions/runs/33904575683)) shows it:

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/p/perl/libperl5.32_5.32.1-4+deb11u5_amd64.deb  404  Not Found
```

Pinning to `archive.debian.org` is not a way out: the archive carries no `bullseye-security` suite, while the base image already ships packages from it, so the two cannot be reconciled without downgrading security updates.

## Changes

- Base image `debian:bullseye-slim` → `debian:trixie-slim` (Debian 13, OpenLDAP 2.6).
- `mkdir -p /var/run/slapd` in the entrypoint. On 2.6's packaging that directory is created by systemd-tmpfiles during boot, which never runs in a container.
- Drop the `ldapadd` of `/etc/ldap/schema/ppolicy.ldif`. 2.6 builds the ppolicy schema into the overlay and ships no such file, so loading it fails.
- `test_password_expire` now expects `grace == 0` where 2.4 reported `1`.

That last one is a reporting change rather than a behavioral one: 2.6 decrements the grace counter for the bind being performed before returning it in the control, and moves the exhaustion check from `< 1` to `< 0` to match. The same single grace login is still granted; an expired password now reports zero remaining where 2.4 reported one.

## Test plan

- [x] Image builds, server starts, schema and overlays load.
- [x] Full suite on Ubuntu, CPython 3.10–3.14: **5/5 green** ([34194690062](https://github.com/dexteradeus/bonsai/actions/runs/34194690062)).

## The macOS jobs on this branch

macOS is red here, on a failure that is already red on `master` and is unrelated to this change. Homebrew now ships OpenLDAP 2.7, which reports an unresolvable hostname as `LDAP_X_SERVER_UNKNOWN` (-19) where earlier versions folded it into the general -1. bonsai does not map -19, so `test_connection_error` gets a bare `LDAPError` instead of the `bonsai.ConnectionError` it expects. The same failure appears in the 2026-09-04 run above.

That is fixed separately in #115, and with both applied the whole matrix is green ([34194689895](https://github.com/dexteradeus/bonsai/actions/runs/34194689895)). Happy to fold that commit into this PR instead if you would rather have a single green change.
